### PR TITLE
[SOAL-1500] fix to address runAsNonRoot while deploying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN wget -qO- https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar
     && pip3 install yq \
     && curl -LO https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
 
-USER argocd
+USER 999
 
 # Install helm secrets
 RUN /usr/local/bin/helm.bin plugin install https://github.com/jkroepke/helm-secrets --version ${HELM_SECRETS_VERSION} &&\


### PR DESCRIPTION
Base images are using numeric user 999 in Dockerfile while softonic image switches using username `argocd` 
This is causing deployment to fail with runAsNonRoot message

Fixing this switch to match with base image